### PR TITLE
Support absolute cell references in formula copy/paste

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
     // In-memory sheet data model
     let rows = 30, cols = 12;
     let data = createEmpty(rows, cols); // stores raw strings (including formulas)
+    let copyOrigin = null; // track source cell for copy/paste
 
     // Error map: key "r,c" -> message
     const errMap = new Map();
@@ -192,11 +193,30 @@
       let s=''; n = n>>>0; do{ s = String.fromCharCode(65 + (n % 26)) + s; n = Math.floor(n/26) - 1; } while(n>=0); return s;
     }
     function parseA1(ref){
-      const m = /^([A-Z]+)(\d+)$/.exec(ref.toUpperCase());
+      const m = /^(\$?)([A-Z]+)(\$?)(\d+)$/.exec(ref.toUpperCase());
       if(!m) return null;
-      const c = m[1].split('').reduce((a,ch)=>a*26 + (ch.charCodeAt(0)-64),0)-1;
-      const r = parseInt(m[2],10)-1;
-      return {r, c};
+      const absCol = !!m[1];
+      const absRow = !!m[3];
+      const c = m[2].split('').reduce((a,ch)=>a*26 + (ch.charCodeAt(0)-64),0)-1;
+      const r = parseInt(m[4],10)-1;
+      return {r, c, absRow, absCol};
+    }
+
+    function shiftFormulaRefs(expr, dr, dc){
+      return expr.replace(/\$?[A-Za-z]+\$?\d+(?::\$?[A-Za-z]+\$?\d+)?/g, ref=>{
+        if(ref.includes(':')){
+          const [a,b] = ref.split(':');
+          return shiftSingle(a)+':'+shiftSingle(b);
+        }
+        return shiftSingle(ref);
+      });
+      function shiftSingle(rf){
+        const p = parseA1(rf);
+        if(!p) return rf;
+        const row = p.absRow ? p.r : p.r + dr;
+        const col = p.absCol ? p.c : p.c + dc;
+        return (p.absCol?'$':'') + colLabel(col) + (p.absRow?'$':'') + (row+1);
+      }
     }
 
     // Rendering
@@ -327,22 +347,22 @@
           tokens.push({type:'num', value:parseFloat(str.slice(s,i))});
           continue;
         }
-        if(isAlpha(ch)){
-          let s=i; while(isAlpha(str[i])) i++; const letters=str.slice(s,i).toUpperCase();
-          let j=i; while(isDigit(str[j])) j++;
-          if(j>i){
-            const cell1=parseA1(letters+str.slice(i,j)); i=j;
+        if(isAlpha(ch) || ch==='$'){
+          const m = /^\$?[A-Za-z]+\$?\d+/.exec(str.slice(i));
+          if(m){
+            const cell1=parseA1(m[0]); i+=m[0].length;
             if(str[i]===':'){
-              i++; let s2=i; while(isAlpha(str[i])) i++; const letters2=str.slice(s2,i).toUpperCase();
-              let k=i; while(isDigit(str[k])) k++;
-              if(k===i) throw new Error('Invalid range');
-              const cell2=parseA1(letters2+str.slice(i,k)); i=k;
+              const m2 = /^\$?[A-Za-z]+\$?\d+/.exec(str.slice(i+1));
+              if(!m2) throw new Error('Invalid range');
+              const cell2=parseA1(m2[0]);
+              i += 1 + m2[0].length;
               tokens.push({type:'range', start:cell1, end:cell2});
             }else{
               tokens.push({type:'cell', pos:cell1});
             }
             continue;
           }
+          let s=i; while(isAlpha(str[i])) i++; const letters=str.slice(s,i).toUpperCase();
           tokens.push({type:'id', value:letters});
           continue;
         }
@@ -639,6 +659,14 @@
       if (e.key === 'ArrowRight'&& (e.ctrlKey||e.metaKey)) return go(r, c+1);
     });
 
+    tbody.addEventListener('copy', (e)=>{
+      const el = document.activeElement?.closest('.cell');
+      copyOrigin = el ? {r:+el.dataset.r, c:+el.dataset.c} : null;
+    });
+    tbody.addEventListener('cut', (e)=>{
+      const el = document.activeElement?.closest('.cell');
+      copyOrigin = el ? {r:+el.dataset.r, c:+el.dataset.c} : null;
+    });
     // ===== Paste from Excel/Sheets (tab/newline grid paste) =====
     tbody.addEventListener('paste', (e)=>{
       const el = e.target.closest('.cell'); if (!el) return;
@@ -647,13 +675,22 @@
       if (!text) return;
       const rowsClip = text.replace(/\r/g,'').split('\n').map(r=>r.split('\t'));
       const r0 = +el.dataset.r, c0 = +el.dataset.c;
+      const dr = copyOrigin ? r0 - copyOrigin.r : 0;
+      const dc = copyOrigin ? c0 - copyOrigin.c : 0;
       for (let i=0;i<rowsClip.length;i++){
         for (let j=0;j<rowsClip[i].length;j++){
           const rr = r0+i, cc = c0+j;
-          if (rr<rows && cc<cols){ data[rr][cc] = rowsClip[i][j]; }
+          if (rr<rows && cc<cols){
+            let cellText = rowsClip[i][j];
+            if(copyOrigin && typeof cellText==='string' && cellText.startsWith('=')){
+              cellText = '=' + shiftFormulaRefs(cellText.slice(1), dr, dc);
+            }
+            data[rr][cc] = cellText;
+          }
         }
       }
       renderBody(); recalc();
+      copyOrigin = null;
     });
 
     // ===== Auto-fit columns (lightweight) =====
@@ -754,6 +791,16 @@
       data[0][2]='=SUM(1,A1)';
       const err2 = valueAt(0,2);
       results.push(err2 && err2.error==='#VALUE!' ? '✓ SUM(1,A1) -> #VALUE!' : `✗ SUM(1,A1) expected #VALUE! got ${String(err2)}`);
+
+      // Added Test 12: Absolute reference shifting
+      rows=3; cols=3; data=createEmpty(rows,cols);
+      data[0][0]='1'; data[1][0]='2'; data[0][1]='3'; data[1][1]='4';
+      const baseFormula='=$A$1+$A1+A$1+A1';
+      const shifted='='+shiftFormulaRefs(baseFormula.slice(1),1,1);
+      const okAbs = shifted==='=$A$1+$A2+B$1+B2';
+      data[2][2]=shifted;
+      const absVal = valueAt(2,2);
+      results.push(okAbs && absVal===10 ? '✓ $A$1/$A1/A$1 refs' : `✗ $ refs failed (${shifted} -> ${absVal})`);
 
       // Restore again
       rows=bakRows; cols=bakCols; data=bak; renderHeader(); renderBody();


### PR DESCRIPTION
## Summary
- Parse A1 references with optional `$` markers to track absolute rows or columns
- Adjust formulas during copy/paste using `shiftFormulaRefs` to respect absolute references
- Extend runtime self-tests for `$A$1`, `$A1`, and `A$1` handling

## Testing
- `node -e "console.log('no tests to run')"`


------
https://chatgpt.com/codex/tasks/task_e_68b007f37b2483319bbd5f84d3d7544c