### PR TITLE
Add runtime tests for advanced formula features

### DIFF
--- a/index.html
+++ b/index.html
@@ -738,7 +738,7 @@
       data[0][0]='5'; data[0][1]='15';
       data[1][0]='=SUM(MIN(A1:B1), MAX(A1:B1), AVERAGE(A1:B1))';
       const nested = valueAt(1,0);
-      results.push(nested===30 ? '✓ Nested MIN/MAX/AVERAGE' : `✗ Nested functions expected 30 got ${nested}`);
+      results.push(nested===30 ? '✓ Nested MIN/MAX/AVERAGE == 30' : `✗ Nested functions expected 30 got ${nested}`);
 
       // Added Test 10: Parentheses precedence
       data[1][1]='=(1+2)*3';
@@ -754,6 +754,34 @@
       data[0][2]='=SUM(1,A1)';
       const err2 = valueAt(0,2);
       results.push(err2 && err2.error==='#VALUE!' ? '✓ SUM(1,A1) -> #VALUE!' : `✗ SUM(1,A1) expected #VALUE! got ${String(err2)}`);
+
+      // Added Test 12: MAX and AVERAGE functions
+      rows=1; cols=3; data=createEmpty(rows,cols);
+      data[0][0]='1'; data[0][1]='5'; data[0][2]='=MAX(A1:B1)';
+      const maxVal = valueAt(0,2);
+      results.push(maxVal===5 ? '✓ MAX(A1:B1) == 5' : `✗ MAX expected 5 got ${maxVal}`);
+      data[0][2]='=AVERAGE(A1:B1)';
+      const avgVal = valueAt(0,2);
+      results.push(avgVal===3 ? '✓ AVERAGE(A1:B1) == 3' : `✗ AVERAGE expected 3 got ${avgVal}`);
+
+      // Added Test 13: Absolute and mixed references
+      rows=2; cols=2; data=createEmpty(rows,cols);
+      data[0][0]='1'; data[0][1]='2';
+      data[1][0]='=A1+$B$1';
+      const absRef = valueAt(1,0);
+      results.push(absRef===3 ? '✓ A1+$B$1 == 3' : `✗ A1+$B$1 expected 3 got ${absRef}`);
+      data[1][1]='=$A1*B$1';
+      const mixedRef = valueAt(1,1);
+      results.push(mixedRef===2 ? '✓ $A1*B$1 == 2' : `✗ $A1*B$1 expected 2 got ${mixedRef}`);
+
+      // Added Test 14: Error propagation (#DIV/0!)
+      rows=1; cols=2; data=createEmpty(rows,cols);
+      data[0][0]='=1/0';
+      const divErr = valueAt(0,0);
+      results.push(divErr && divErr.error==='#DIV/0!' ? '✓ 1/0 -> #DIV/0!' : `✗ 1/0 expected #DIV/0! got ${String(divErr)}`);
+      data[0][1]='=A1+1';
+      const propErr = valueAt(0,1);
+      results.push(propErr && propErr.error==='#DIV/0!' ? '✓ A1+1 propagates #DIV/0!' : `✗ A1+1 expected #DIV/0! got ${String(propErr)}`);
 
       // Restore again
       rows=bakRows; cols=bakCols; data=bak; renderHeader(); renderBody();


### PR DESCRIPTION
## Summary
- expand runTests with MAX and AVERAGE checks
- verify absolute and mixed cell references
- ensure errors like #DIV/0! propagate correctly

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b00964dc688331b847e973eb0001d0