### PR TITLE
Fix active cell overwriting during recalculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,7 +283,9 @@
 
     function refreshAllDisplay(){
       const snap = getCaret();
+      const active = document.activeElement;
       for(const el of tbody.querySelectorAll('.cell')){
+        if (el === active) continue; // keep user input while editing
         const r = +el.dataset.r, c = +el.dataset.c;
         const newText = displayValue(r,c);
         if (el.textContent !== newText) el.textContent = newText;


### PR DESCRIPTION
## Summary
- Avoid recalculation from overwriting the cell currently being edited, preserving the `=` prefix while typing formulas

## Testing
- `node - <<'NODE' ...` (formula evaluator returns correct result)


------
https://chatgpt.com/codex/tasks/task_e_68b00d7ccd108331aabe949c735e56ca