### PR TITLE
Handle clipboard errors in debug report copy

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,8 +39,13 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     document.getElementById('copyDebug').onclick = async ()=>{
       const report = collectReport();
-      await navigator.clipboard.writeText(report);
-      fileInfo.textContent = 'Debug report copied to clipboard';
+      try {
+        await navigator.clipboard.writeText(report);
+        fileInfo.textContent = 'Debug report copied to clipboard';
+      } catch (e) {
+        fileInfo.textContent = 'Failed to copy debug report';
+        log('Failed to copy debug report', e);
+      }
     };
     function collectReport(){
       // basic environment + last 200 lines of debug


### PR DESCRIPTION
## Summary
- handle clipboard failures in Copy Report by wrapping clipboard write in try/catch
- notify user when copying debug report fails and log the error

## Testing
- `node test script` *(simulated clipboard denial; fileInfo updated)*

------
https://chatgpt.com/codex/tasks/task_e_68b018bd61ec8331a90227e22ea70818