### PR TITLE
feat: add undo and redo functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
     <button id="boldBtn" title="Bold"><b>B</b></button>
     <button id="italicBtn" title="Italic"><i>I</i></button>
     <input id="fillColor" type="color" title="Fill color" />
+    <button id="undoBtn" title="Undo">Undo</button>
+    <button id="redoBtn" title="Redo">Redo</button>
 
     <div class="toolbar">
       <label class="btn-file" title="Open CSV/XLSX">


### PR DESCRIPTION
## Summary
- Track spreadsheet edits with new undo/redo stacks and snapshot helpers
- Support undo/redo via keyboard shortcuts and toolbar buttons
- Capture edits from cell entry, grid modifications, and pasting

## Testing
- `node --check app.js`
- `npm test` *(fails: no such file or directory 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b023a10bf08331bf2fc26d15eac291