### PR TITLE
Add column and row resizing with drag handles

### DIFF
--- a/style.css
+++ b/style.css
@@ -24,6 +24,8 @@
   tr:nth-child(even) td{background:var(--grid)}
   tr:nth-child(odd) td{background:#0e1430}
   .cell.err{background:var(--err)!important;border:1px solid var(--errBorder)}
+  .col-resizer{position:absolute;top:0;right:0;width:4px;height:100%;cursor:col-resize;user-select:none}
+  .row-resizer{position:absolute;bottom:0;left:0;width:100%;height:4px;cursor:row-resize;user-select:none}
   .status{display:flex;gap:1rem;align-items:center;margin-top:10px;color:var(--muted);flex-wrap:wrap}
   .status code{background:#0f1734;border:1px solid #1b254b;border-radius:8px;padding:.25rem .5rem;color:#bfe}
   .pill{border:1px solid #2a3b76;border-radius:999px;padding:.2rem .5rem}


### PR DESCRIPTION
## Summary
- Append draggable resize handles to column and row headers
- Support drag events to change column width and row height and persist custom sizes
- Respect user-defined widths in `autofitColumns`

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b024b158d48331a0815e585303b39b