### PR TITLE
Add sheet tabs and multi-sheet export support

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,10 +29,7 @@
       </label>
       <button id="saveCSV" title="Download as CSV">Export CSV</button>
       <button id="saveXLSX" title="Download as XLSX">Export XLSX</button>
-      <div id="sheetPicker" class="sheetPicker">
-        <span>Sheet:</span>
-        <select id="sheetSelect"></select>
-      </div>
+      <div id="sheetTabs" class="sheetTabs"></div>
       <button id="runTests" title="Quick self-test">Run Tests</button>
       <button id="toggleDebug" title="Show/hide debug log">Debug</button>
       <button id="copyDebug" title="Copy debug report">Copy Report</button>

--- a/style.css
+++ b/style.css
@@ -32,8 +32,11 @@
   .hint{opacity:.8}
   .danger{color:#ff9da6}
   .ok{color:#9dffb3}
-  .sheetPicker{display:none;gap:.5rem;align-items:center}
-  .sheetPicker.active{display:flex}
+  .sheetTabs{display:flex;gap:.25rem;align-items:center}
+  .sheetTab{padding:.25rem .6rem;background:#1a2450;border:1px solid #2c3a74;border-radius:10px 10px 0 0;cursor:pointer;position:relative;}
+  .sheetTab.active{background:#21306b}
+  .sheetTab .close{margin-left:.5rem;cursor:pointer}
+  .sheetTab.add{font-weight:600}
   .debug{margin-top:10px;background:#0a122e;border:1px solid #1b254b;border-radius:12px;padding:8px;max-height:20vh;overflow:auto}
   .debug h3{margin:0 0 6px 0;font-size:12px;color:#bcd}
   .debug pre{margin:0;font-size:12px;white-space:pre-wrap;word-break:break-word}


### PR DESCRIPTION
## Summary
- Replace sheet select dropdown with tabbed interface for navigating sheets.
- Maintain array of sheet objects with active sheet tracking and tab handlers for adding, renaming, deleting, and switching.
- Persist all sheets when exporting to CSV (zip) or XLSX and load multi-sheet workbooks.

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b025c90eb883319fdd527a3bddcbeb