### PR TITLE
Handle blank cells as #VALUE! errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -479,6 +479,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function isErr(v){ return v && typeof v === 'object' && 'error' in v; }
     function numeric(v){
       if(isErr(v)) return v;
+      if(v === '') return VALUE_ERROR;
       const n = Number(v);
       return isFinite(n) ? n : VALUE_ERROR;
     }
@@ -1088,7 +1089,13 @@ document.addEventListener('DOMContentLoaded', () => {
       const err2 = valueAt(0,2);
       results.push(err2 && err2.error==='#VALUE!' ? '✓ SUM(1,A1) -> #VALUE!' : `✗ SUM(1,A1) expected #VALUE! got ${String(err2)}`);
 
-      // Added Test 12: Absolute reference shifting
+      // Added Test 12: Blank cell reference -> #VALUE!
+      data=createEmpty(rows,cols);
+      data[0][1].value='=1+A1';
+      const errBlank = valueAt(0,1);
+      results.push(errBlank && errBlank.error==='#VALUE!' ? '✓ 1+A1 with A1 blank -> #VALUE!' : `✗ 1+A1 blank expected #VALUE! got ${String(errBlank)}`);
+
+      // Added Test 13: Absolute reference shifting
       rows=3; cols=3; data=createEmpty(rows,cols);
       data[0][0].value='1'; data[1][0].value='2'; data[0][1].value='3'; data[1][1].value='4';
       const baseFormula='=$A$1+$A1+A$1+A1';

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
       </table>
     </div>
     <div class="status">
-      <span class="pill hint">Tip: use formulas like <code>=A1+B2*2</code> or <code>=SUM(A1:A5,B2)</code></span>
+      <span class="pill hint">Tip: use formulas like <code>=A1+B2*2</code> or <code>=SUM(A1:A5,B2)</code>; blank cells return <code>#VALUE!</code></span>
       <span id="calcState" class="pill">Ready</span>
       <span id="xlsxState" class="pill">XLSX: not loaded</span>
       <span id="fileInfo" class="pill"></span>


### PR DESCRIPTION
## Summary
- Treat empty strings as `#VALUE!` in numeric conversions
- Add self-test ensuring blank cell references yield `#VALUE!`
- Update UI hint to note that blank cells return `#VALUE!`

## Testing
- `node --check app.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0de4322ac8331b162406ddb76c66f