### PR TITLE
Prevent formula cursor from trapping at sheet edges

### DIFF
--- a/app.js
+++ b/app.js
@@ -975,25 +975,38 @@ document.addEventListener('DOMContentLoaded', () => {
       
       // Excel-like formula navigation: insert cell references when editing formulas
       const insertCellRef = (deltaR, deltaC) => {
+        // Compute target location before clamping
+        const targetR = formulaVirtualCursor.r + deltaR;
+        const targetC = formulaVirtualCursor.c + deltaC;
+
+        const newR = Math.max(0, Math.min(rows-1, targetR));
+        const newC = Math.max(0, Math.min(cols-1, targetC));
+
+        // If clamping results in no movement, allow default caret navigation
+        if (newR === formulaVirtualCursor.r && newC === formulaVirtualCursor.c) {
+          formulaVirtualCursor.active = false;
+          return;
+        }
+
         e.preventDefault();
-        
+
         // Move virtual cursor
-        formulaVirtualCursor.r = Math.max(0, Math.min(rows-1, formulaVirtualCursor.r + deltaR));
-        formulaVirtualCursor.c = Math.max(0, Math.min(cols-1, formulaVirtualCursor.c + deltaC));
-        
+        formulaVirtualCursor.r = newR;
+        formulaVirtualCursor.c = newC;
+
         const ref = colLabel(formulaVirtualCursor.c) + (formulaVirtualCursor.r + 1);
         const currentText = el.textContent;
         const selection = window.getSelection();
-        
+
         if (selection.rangeCount > 0) {
           const range = selection.getRangeAt(0);
           const newText = currentText.slice(0, range.startOffset) + ref + currentText.slice(range.endOffset);
           el.textContent = newText;
-          
+
           // Update data and formula bar
           data[r][c].value = newText;
           formulaBar.value = newText;
-          
+
           // Select the inserted reference so subsequent arrow presses replace it
           const start = range.startOffset;
           const end = start + ref.length;
@@ -1003,7 +1016,7 @@ document.addEventListener('DOMContentLoaded', () => {
           newRange.setEnd(textNode, Math.min(end, textNode.textContent?.length || 0));
           selection.removeAllRanges();
           selection.addRange(newRange);
-          
+
           recalc();
         }
       };


### PR DESCRIPTION
## Summary
- compute virtual cursor target before clamping
- skip cell reference insertion if arrow key would stay in same cell so caret moves normally

## Testing
- `npm test` *(fails: missing package.json)*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b0e7310bcc833182779cebc34beed9