### PR TITLE
feat: add accessible hamburger navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -1275,12 +1275,14 @@ document.addEventListener('DOMContentLoaded', () => {
     // ===== Hamburger menu toggle =====
     const hamburgerBtn = document.getElementById('hamburgerBtn');
     const headerNav = document.getElementById('headerNav');
-    
+
     if (hamburgerBtn && headerNav) {
+      headerNav.setAttribute('aria-expanded', 'false');
       hamburgerBtn.addEventListener('click', (e) => {
         e.preventDefault();
         const isOpen = headerNav.classList.contains('open');
         headerNav.classList.toggle('open', !isOpen);
+        headerNav.setAttribute('aria-expanded', (!isOpen).toString());
         hamburgerBtn.setAttribute('aria-expanded', (!isOpen).toString());
         hamburgerBtn.classList.toggle('active', !isOpen);
       });
@@ -1289,6 +1291,7 @@ document.addEventListener('DOMContentLoaded', () => {
       document.addEventListener('click', (e) => {
         if (!e.target.closest('header')) {
           headerNav.classList.remove('open');
+          headerNav.setAttribute('aria-expanded', 'false');
           hamburgerBtn.setAttribute('aria-expanded', 'false');
           hamburgerBtn.classList.remove('active');
         }
@@ -1298,6 +1301,7 @@ document.addEventListener('DOMContentLoaded', () => {
       document.addEventListener('keydown', (e) => {
         if (e.key === 'Escape' && headerNav.classList.contains('open')) {
           headerNav.classList.remove('open');
+          headerNav.setAttribute('aria-expanded', 'false');
           hamburgerBtn.setAttribute('aria-expanded', 'false');
           hamburgerBtn.classList.remove('active');
         }

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <header>
     <div class="header-main">
       <h1>Mini Excel Editor</h1>
-      <button id="hamburgerBtn" class="hamburger" aria-label="Toggle menu" aria-expanded="false">
+      <button id="hamburgerBtn" class="hamburger" aria-label="Toggle menu" aria-controls="headerNav" aria-expanded="false">
         <span></span>
         <span></span>
         <span></span>


### PR DESCRIPTION
## Summary
- link hamburger button to nav with `aria-controls`
- toggle `aria-expanded` on navigation menu and button

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b10c9d0930833187b4856a439f8c9d