### PR TITLE
Sync bold and italic toolbar state with aria-pressed

### DIFF
--- a/app.js
+++ b/app.js
@@ -413,6 +413,8 @@ document.addEventListener('DOMContentLoaded', () => {
         formulaBar.dataset.r = r;
         formulaBar.dataset.c = c;
         if(fillColorInput) fillColorInput.value = cell.bgColor || '#ffffff';
+        if(boldBtn) boldBtn.setAttribute('aria-pressed', cell.bold ? 'true' : 'false');
+        if(italicBtn) italicBtn.setAttribute('aria-pressed', cell.italic ? 'true' : 'false');
 
         // Highlight row/column headers for the active cell
         if (typeof lastHeader !== 'undefined') {
@@ -708,6 +710,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const {r,c} = activeCell;
         const cell = data[r][c];
         cell.bold = !cell.bold;
+        boldBtn.setAttribute('aria-pressed', cell.bold ? 'true' : 'false');
         const el = tbody.querySelector(`.cell[data-r="${r}"][data-c="${c}"]`);
         if(el) applyCellStyles(el, cell);
       });
@@ -715,6 +718,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const {r,c} = activeCell;
         const cell = data[r][c];
         cell.italic = !cell.italic;
+        italicBtn.setAttribute('aria-pressed', cell.italic ? 'true' : 'false');
         const el = tbody.querySelector(`.cell[data-r="${r}"][data-c="${c}"]`);
         if(el) applyCellStyles(el, cell);
       });

--- a/style.css
+++ b/style.css
@@ -7,6 +7,7 @@
   button, .btn-file, select, input[type="color"]{background:#1a2450;border:1px solid #2c3a74;border-radius:10px;padding:.5rem .75rem;color:var(--text);cursor:pointer}
   button:hover,.btn-file:hover, select:hover, input[type="color"]:hover{background:#21306b}
   button[disabled]{opacity:.55;cursor:not-allowed}
+  button[aria-pressed="true"]{background:var(--sel);box-shadow:inset 0 0 0 2px var(--accent)}
   .btn-file{position:relative;overflow:hidden;display:inline-flex;align-items:center;gap:.5rem}
   .btn-file input{position:absolute;inset:0;opacity:0;cursor:pointer}
   .toolbar{display:flex;flex-wrap:wrap;gap:.5rem;margin-left:auto}


### PR DESCRIPTION
## Summary
- Toggle `aria-pressed` on bold and italic toolbar buttons
- Update buttons when active cell changes to reflect formatting
- Style `aria-pressed="true"` state for clearer feedback

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b115c28b588331b2e6f1392d4efd3e