### PR TITLE
feat: make add tab keyboard accessible

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,8 +50,10 @@ document.addEventListener('DOMContentLoaded', () => {
         tab.appendChild(close);
         sheetTabs.appendChild(tab);
       });
-      const add=document.createElement('div');
+      const add=document.createElement('button');
       add.className='sheetTab add';
+      add.type='button';
+      add.setAttribute('aria-label','Add new sheet');
       add.textContent='+';
       sheetTabs.appendChild(add);
     }


### PR DESCRIPTION
## Summary
- use a `<button>` for the sheet-add tab
- label it with `aria-label="Add new sheet"` for screen readers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b123092e648331bab7a6a92451b90b