### PR TITLE
feat: enhance sheet tab UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,14 +40,18 @@ document.addEventListener('DOMContentLoaded', () => {
     function renderTabs(){
       sheetTabs.innerHTML='';
       sheets.forEach((s,i)=>{
-        const tab=document.createElement('div');
+        const tab=document.createElement('button');
+        tab.type='button';
         tab.className='sheetTab'+(i===activeSheetIndex?' active':'');
         tab.textContent=s.name;
         tab.dataset.idx=i;
-        const close=document.createElement('span');
-        close.textContent='×';
-        close.className='close';
-        tab.appendChild(close);
+        if(sheets.length>1){
+          const close=document.createElement('span');
+          close.textContent='×';
+          close.className='close';
+          close.setAttribute('aria-label','Close sheet');
+          tab.appendChild(close);
+        }
         sheetTabs.appendChild(tab);
       });
       const add=document.createElement('button');

--- a/style.css
+++ b/style.css
@@ -35,11 +35,13 @@
   .hint{opacity:.8}
   .danger{color:#ff9da6}
   .ok{color:#9dffb3}
-  .sheetTabs{display:flex;gap:.25rem;align-items:center}
-  .sheetTab{padding:.25rem .6rem;background:#1a2450;border:1px solid #2c3a74;border-radius:10px 10px 0 0;cursor:pointer;position:relative;}
-  .sheetTab.active{background:#21306b}
-  .sheetTab .close{margin-left:.5rem;cursor:pointer}
-  .sheetTab.add{font-weight:600}
+.sheetTabs{display:flex;gap:.25rem;align-items:center}
+.sheetTab{display:flex;align-items:center;gap:.25rem;padding:.25rem .6rem;background:#1a2450;border:1px solid #2c3a74;border-radius:10px 10px 0 0;cursor:pointer;position:relative;}
+.sheetTab.active{background:#21306b}
+.sheetTab .close{margin-left:.15rem;font-weight:600;cursor:pointer;opacity:0;transition:opacity .2s}
+.sheetTab:hover .close{opacity:.8}
+.sheetTab.add{font-weight:600}
+.sheetTab:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
   .debug{margin-top:10px;background:#0a122e;border:1px solid #1b254b;border-radius:12px;padding:8px;max-height:20vh;overflow:auto}
   .debug h3{margin:0 0 6px 0;font-size:12px;color:#bcd}
   .debug pre{margin:0;font-size:12px;white-space:pre-wrap;word-break:break-word}


### PR DESCRIPTION
## Summary
- render sheet tabs as buttons with accessible close controls
- restyle sheet tabs with flex layout, hover close icons, and keyboard focus

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1301768588331a1a56ef69483c4a2