### PR TITLE
style: adopt google-like sheet ui

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,23 +39,27 @@ document.addEventListener('DOMContentLoaded', () => {
     // Sheet tab helpers
     function renderTabs(){
       sheetTabs.innerHTML='';
-      sheets.forEach((s,i)=>{
-        const tab=document.createElement('div');
-        tab.className='sheetTab'+(i===activeSheetIndex?' active':'');
-        tab.textContent=s.name;
-        tab.dataset.idx=i;
-        const close=document.createElement('span');
-        close.textContent='×';
-        close.className='close';
-        tab.appendChild(close);
-        sheetTabs.appendChild(tab);
-      });
       const add=document.createElement('button');
       add.className='sheetTab add';
       add.type='button';
       add.setAttribute('aria-label','Add new sheet');
       add.textContent='+';
       sheetTabs.appendChild(add);
+      sheets.forEach((s,i)=>{
+        const tab=document.createElement('button');
+        tab.type='button';
+        tab.className='sheetTab'+(i===activeSheetIndex?' active':'');
+        tab.textContent=s.name;
+        tab.dataset.idx=i;
+        if(sheets.length>1){
+          const close=document.createElement('span');
+          close.textContent='×';
+          close.className='close';
+          close.setAttribute('aria-label','Close sheet');
+          tab.appendChild(close);
+        }
+        sheetTabs.appendChild(tab);
+      });
     }
     function saveActiveState(){
       const s=sheets[activeSheetIndex];

--- a/index.html
+++ b/index.html
@@ -11,63 +11,62 @@
   <header>
     <div class="header-main">
       <h1>Mini Excel Editor</h1>
+
+      <nav id="headerNav" class="header-nav" aria-expanded="false">
+        <div class="group" role="group" aria-label="File">
+          <button id="newSheet" title="New blank sheet">New</button>
+        </div>
+
+        <div class="group" role="group" aria-label="Grid">
+          <button id="addRow" title="Add a row">+ Row</button>
+          <button id="addCol" title="Add a column">+ Col</button>
+          <button id="delRow" title="Delete last row">– Row</button>
+          <button id="delCol" title="Delete last column">– Col</button>
+        </div>
+
+        <div class="group" role="group" aria-label="Cell formatting">
+          <button id="boldBtn" title="Bold" aria-pressed="false"><b>B</b></button>
+          <button id="italicBtn" title="Italic" aria-pressed="false"><i>I</i></button>
+          <label for="fillColor" class="visually-hidden">Fill Color</label>
+          <input id="fillColor" type="color" title="Fill color" />
+          <button id="undoBtn" title="Undo">Undo</button>
+          <button id="redoBtn" title="Redo">Redo</button>
+        </div>
+
+        <label for="formulaBar" class="visually-hidden">Formula</label>
+        <input id="formulaBar" type="text" placeholder="fx" />
+
+        <div class="toolbar">
+          <label class="btn-file" title="Open CSV/XLSX">
+            Open
+            <input id="fileInput" type="file" accept=".csv, text/csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, .xlsx" />
+          </label>
+
+          <div class="menu">
+            <button class="menu-trigger" aria-haspopup="true" aria-expanded="false" title="Export options">Export ▾</button>
+            <div class="menu-items" role="menu" aria-label="Export">
+              <button id="saveCSV" title="Download as CSV" role="menuitem">Export CSV</button>
+              <button id="saveXLSX" title="Download as XLSX" role="menuitem">Export XLSX</button>
+            </div>
+          </div>
+
+          <div class="menu">
+            <button class="menu-trigger" aria-haspopup="true" aria-expanded="false" title="Advanced tools">Advanced ▾</button>
+            <div class="menu-items right" role="menu" aria-label="Advanced">
+              <button id="runTests" title="Quick self-test" role="menuitem">Run Tests</button>
+              <button id="toggleDebug" title="Show/hide debug log" role="menuitem">Debug</button>
+              <button id="copyDebug" title="Copy debug report" role="menuitem">Copy Report</button>
+            </div>
+          </div>
+        </div>
+      </nav>
+
       <button id="hamburgerBtn" class="hamburger" aria-label="Toggle menu" aria-controls="headerNav" aria-expanded="false">
         <span></span>
         <span></span>
         <span></span>
       </button>
     </div>
-
-    <nav id="headerNav" class="header-nav">
-      <div class="group" role="group" aria-label="File">
-        <button id="newSheet" title="New blank sheet">New</button>
-      </div>
-
-      <div class="group" role="group" aria-label="Grid">
-        <button id="addRow" title="Add a row">+ Row</button>
-        <button id="addCol" title="Add a column">+ Col</button>
-        <button id="delRow" title="Delete last row">– Row</button>
-        <button id="delCol" title="Delete last column">– Col</button>
-      </div>
-
-      <div class="group" role="group" aria-label="Cell formatting">
-        <button id="boldBtn" title="Bold"><b>B</b></button>
-        <button id="italicBtn" title="Italic"><i>I</i></button>
-        <label for="fillColor" class="visually-hidden">Fill Color</label>
-        <input id="fillColor" type="color" title="Fill color" />
-        <button id="undoBtn" title="Undo">Undo</button>
-        <button id="redoBtn" title="Redo">Redo</button>
-      </div>
-
-      <label for="formulaBar" class="visually-hidden">Formula</label>
-      <input id="formulaBar" type="text" placeholder="fx" />
-
-      <div class="toolbar">
-        <label class="btn-file" title="Open CSV/XLSX">
-          Open
-          <input id="fileInput" type="file" accept=".csv, text/csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, .xlsx" />
-        </label>
-
-        <div class="menu">
-          <button class="menu-trigger" aria-haspopup="true" aria-expanded="false" title="Export options">Export ▾</button>
-          <div class="menu-items" role="menu" aria-label="Export">
-            <button id="saveCSV" title="Download as CSV" role="menuitem">Export CSV</button>
-            <button id="saveXLSX" title="Download as XLSX" role="menuitem">Export XLSX</button>
-          </div>
-        </div>
-
-        <div id="sheetTabs" class="sheetTabs"></div>
-
-        <div class="menu">
-          <button class="menu-trigger" aria-haspopup="true" aria-expanded="false" title="Advanced tools">Advanced ▾</button>
-          <div class="menu-items right" role="menu" aria-label="Advanced">
-            <button id="runTests" title="Quick self-test" role="menuitem">Run Tests</button>
-            <button id="toggleDebug" title="Show/hide debug log" role="menuitem">Debug</button>
-            <button id="copyDebug" title="Copy debug report" role="menuitem">Copy Report</button>
-          </div>
-        </div>
-      </div>
-    </nav>
   </header>
 
   <div class="wrap">
@@ -76,6 +75,9 @@
         <thead></thead>
         <tbody></tbody>
       </table>
+    </div>
+    <div class="sheetTabsBar">
+      <div id="sheetTabs" class="sheetTabs"></div>
     </div>
     <div class="status">
       <span class="pill hint">Tip: use formulas like <code>=A1+B2*2</code> or <code>=SUM(A1:A5,B2)</code>; blank cells return <code>#VALUE!</code></span>

--- a/style.css
+++ b/style.css
@@ -1,23 +1,25 @@
-  :root { --bg:#0b1020; --panel:#121932; --grid:#0f1530; --muted:#9fb0d0; --text:#e8eeff; --accent:#5ea0ff; --sel:#24325e; --err:#3b0f1a; --errBorder:#ff5577; }
+  :root { --bg:#f8f9fa; --panel:#ffffff; --grid:#ffffff; --muted:#5f6368; --text:#202124; --accent:#1a73e8; --sel:#e8f0fe; --err:#fce8e6; --errBorder:#d93025; }
   *{box-sizing:border-box}
   .visually-hidden{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
-  body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 system-ui,Segoe UI,Roboto,Arial}
-  header{display:flex;gap:.5rem;align-items:center;padding:.75rem;border-bottom:1px solid #1b254b;background:linear-gradient(180deg,var(--panel),#0f1734)}
-  header h1{font-size:16px;margin:0 1rem 0 0;opacity:.9;font-weight:600;letter-spacing:.2px}
-  button, .btn-file, select, input[type="color"]{background:#1a2450;border:1px solid #2c3a74;border-radius:10px;padding:.5rem .75rem;color:var(--text);cursor:pointer}
-  button:hover,.btn-file:hover, select:hover, input[type="color"]:hover{background:#21306b}
+  body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 system-ui,Segoe UI,Roboto,Arial,sans-serif}
+  header{border-bottom:1px solid #dadce0;background:var(--panel)}
+  .header-main{display:flex;align-items:center;gap:.75rem;padding:.5rem 1rem;width:100%}
+  header h1{font-size:16px;margin:0;font-weight:500;letter-spacing:.2px;color:var(--text);white-space:nowrap}
+  .header-nav{display:flex;align-items:center;gap:.75rem;flex:1}
+  header .group{display:flex;align-items:center;gap:.5rem;border-right:1px solid #dadce0;padding-right:.75rem;margin-right:.75rem}
+  button, .btn-file, select, input[type="color"]{background:#f1f3f4;border:1px solid #dadce0;border-radius:4px;padding:.4rem .75rem;color:var(--text);cursor:pointer}
+  button:hover,.btn-file:hover, select:hover, input[type="color"]:hover{background:#e8eaed}
   button[disabled]{opacity:.55;cursor:not-allowed}
-  button[aria-pressed="true"]{background:var(--sel);box-shadow:inset 0 0 0 2px var(--accent)}
+  button[aria-pressed="true"]{background:var(--sel);box-shadow:inset 0 0 0 1px var(--accent)}
   .btn-file{position:relative;overflow:hidden;display:inline-flex;align-items:center;gap:.5rem}
   .btn-file input{position:absolute;inset:0;opacity:0;cursor:pointer}
-  .toolbar{display:flex;flex-wrap:wrap;gap:.5rem;margin-left:auto}
-  #formulaBar{flex:1;background:#1a2450;border:1px solid #2c3a74;border-radius:10px;padding:.5rem;color:var(--text)}
+  #formulaBar{flex:1;background:#fff;border:1px solid #dadce0;border-radius:4px;padding:.4rem;color:var(--text)}
   .wrap{padding:12px}
-  .sheet{background:var(--panel);border:1px solid #1b254b;border-radius:14px;overflow:auto;max-height:70vh;box-shadow:0 10px 30px rgba(0,0,0,.25)}
+  .sheet{background:var(--panel);border:1px solid #dadce0;border-radius:0;overflow:auto;max-height:70vh}
   table{border-collapse:separate;border-spacing:0;min-width:720px}
-  thead th{position:sticky;top:0;background:#121c3f;z-index:3;color:#cfe0ff;font-weight:600}
-  tbody th{position:sticky;left:0;background:#121c3f;z-index:2;color:#cfe0ff;font-weight:600}
-  th, td{border-right:1px solid #203066;border-bottom:1px solid #203066;min-width:100px}
+  thead th{position:sticky;top:0;background:#f8f9fa;z-index:3;color:#3c4043;font-weight:500}
+  tbody th{position:sticky;left:0;background:#f8f9fa;z-index:2;color:#3c4043;font-weight:500}
+  th, td{border-right:1px solid #dadce0;border-bottom:1px solid #dadce0;min-width:100px}
   thead th:first-child{left:0;z-index:4}
   th{padding:.4rem .5rem;text-align:center}
   td{padding:0}
@@ -25,39 +27,43 @@
   td .cell:focus{background:var(--sel);box-shadow:inset 0 0 0 2px var(--accent);outline:none}
   td .cell.formula-cursor{outline:2px dotted var(--accent);outline-offset:-2px}
   tr:nth-child(even) td{background:var(--grid)}
-  tr:nth-child(odd) td{background:#0e1430}
+  tr:nth-child(odd) td{background:var(--grid)}
   .cell.err{background:var(--err)!important;border:1px solid var(--errBorder)}
   .col-resizer{position:absolute;top:0;right:0;width:4px;height:100%;cursor:col-resize;user-select:none}
   .row-resizer{position:absolute;bottom:0;left:0;width:100%;height:4px;cursor:row-resize;user-select:none}
   .status{display:flex;gap:1rem;align-items:center;margin-top:10px;color:var(--muted);flex-wrap:wrap}
-  .status code{background:#0f1734;border:1px solid #1b254b;border-radius:8px;padding:.25rem .5rem;color:#bfe}
-  .pill{border:1px solid #2a3b76;border-radius:999px;padding:.2rem .5rem}
+  .status code{background:#f1f3f4;border:1px solid #dadce0;border-radius:8px;padding:.25rem .5rem;color:#174ea6}
+  .pill{border:1px solid #dadce0;border-radius:999px;padding:.2rem .5rem}
   .hint{opacity:.8}
-  .danger{color:#ff9da6}
-  .ok{color:#9dffb3}
-  .sheetTabs{display:flex;gap:.25rem;align-items:center}
-  .sheetTab{padding:.25rem .6rem;background:#1a2450;border:1px solid #2c3a74;border-radius:10px 10px 0 0;cursor:pointer;position:relative;}
-  .sheetTab.active{background:#21306b}
-  .sheetTab .close{margin-left:.5rem;cursor:pointer}
-  .sheetTab.add{font-weight:600}
-  .debug{margin-top:10px;background:#0a122e;border:1px solid #1b254b;border-radius:12px;padding:8px;max-height:20vh;overflow:auto}
-  .debug h3{margin:0 0 6px 0;font-size:12px;color:#bcd}
-  .debug pre{margin:0;font-size:12px;white-space:pre-wrap;word-break:break-word}
+  .danger{color:#d93025}
+  .ok{color:#188038}
+.sheetTabsBar{border-top:1px solid #dadce0;background:var(--panel);margin-top:4px}
+.sheetTabs{display:flex;align-items:center;gap:2px;padding:4px;overflow-x:auto}
+.sheetTab{display:flex;align-items:center;gap:.25rem;padding:.25rem .75rem;background:#e8eaed;border:1px solid transparent;border-radius:4px 4px 0 0;color:var(--muted);cursor:pointer}
+.sheetTab.active{background:var(--panel);color:var(--text);border-color:#dadce0;border-bottom:1px solid var(--panel);box-shadow:0 -2px 0 0 var(--accent) inset}
+.sheetTab .close{margin-left:.25rem;font-weight:600;cursor:pointer;opacity:0;transition:opacity .2s}
+.sheetTab:hover .close{opacity:.6}
+.sheetTab.add{padding:0;width:24px;height:24px;border-radius:50%;background:transparent;color:var(--muted);border:0}
+.sheetTab.add:hover{background:#e8eaed}
+.sheetTab:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .debug{margin-top:10px;background:#f1f3f4;border:1px solid #dadce0;border-radius:12px;padding:8px;max-height:20vh;overflow:auto}
+  .debug h3{margin:0 0 6px 0;font-size:12px;color:#202124}
+  .debug pre{margin:0;font-size:12px;white-space:pre-wrap;word-break:break-word;color:#202124}
   .debug .row{opacity:.9}
-  @media (max-width:900px){th, td{min-width:80px} header{gap:.4rem} header h1{display:none}}
+@media (max-width:900px){th, td{min-width:80px} .header-main{gap:.4rem} header h1{display:none}}
 
 /* Medium mobile devices - 600px and below */
 @media (max-width:600px){
   body{font-size:13px}
-  header{padding:.5rem;flex-direction:column;align-items:stretch}
+  .header-main{padding:.5rem;flex-wrap:wrap;align-items:center}
   header h1{font-size:14px;margin:0}
-  
+
   /* Show hamburger menu */
-  .hamburger{display:flex}
-  .header-nav{display:none;flex-direction:column;gap:.5rem;margin-top:.5rem;padding-top:.5rem;border-top:1px solid #1b254b}
+  .hamburger{display:flex;margin-left:auto}
+  .header-nav{display:none;flex-direction:column;gap:.5rem;width:100%;margin-top:.5rem;padding-top:.5rem;border-top:1px solid #dadce0}
   .header-nav.open{display:flex}
-  
-  header .group{gap:.3rem;justify-content:center;flex-wrap:wrap;margin:.25rem 0}
+
+  header .group{gap:.3rem;justify-content:center;flex-wrap:wrap;margin:.25rem 0;border-right:0;padding-right:0;margin-right:0}
   button, .btn-file, select, input[type="color"]{padding:.4rem .6rem;font-size:13px;border-radius:8px}
   #formulaBar{padding:.4rem;font-size:13px;width:100%;margin:.25rem 0}
   .toolbar{gap:.3rem;justify-content:center;flex-wrap:wrap;margin:.25rem 0}
@@ -80,15 +86,15 @@
 /* Small mobile devices - 400px and below */
 @media (max-width:400px){
   body{font-size:12px}
-  header{padding:.4rem;flex-direction:column;align-items:stretch}
+  .header-main{padding:.4rem;flex-wrap:wrap;align-items:center}
   header h1{font-size:13px;margin:0}
-  
+
   /* Hamburger menu styles for smallest screens */
   .hamburger{display:flex;width:26px;height:26px}
   .hamburger span{height:2px;margin:2px 0}
-  .header-nav{gap:.4rem;margin-top:.4rem;padding-top:.4rem}
-  
-  header .group{justify-content:center;flex-wrap:wrap;margin:.2rem 0}
+  .header-nav{gap:.4rem;width:100%;margin-top:.4rem;padding-top:.4rem}
+
+  header .group{justify-content:center;flex-wrap:wrap;margin:.2rem 0;border-right:0;padding-right:0;margin-right:0}
   button, .btn-file, select, input[type="color"]{padding:.3rem .5rem;font-size:12px;border-radius:6px}
   #formulaBar{padding:.3rem;font-size:12px;width:100%;margin:.2rem 0}
   .toolbar{gap:.2rem;justify-content:center;flex-wrap:wrap;margin:.2rem 0}
@@ -112,26 +118,23 @@
 
 
 /* --- Hamburger menu and header navigation --- */
-.header-main{display:flex;justify-content:space-between;align-items:center;width:100%}
 .hamburger{display:none;flex-direction:column;justify-content:center;width:30px;height:30px;background:transparent;border:0;cursor:pointer;padding:0}
 .hamburger span{display:block;height:3px;width:100%;background:var(--text);margin:3px 0;transition:all 0.3s ease;border-radius:2px}
 .hamburger.active span:nth-child(1){transform:rotate(45deg) translate(6px, 6px)}
 .hamburger.active span:nth-child(2){opacity:0}
 .hamburger.active span:nth-child(3){transform:rotate(-45deg) translate(6px, -6px)}
 
-.header-nav{display:flex;gap:.5rem;align-items:center;flex:1}
 .header-nav.open{display:flex}
 
 /* --- Toolbar grouping and dropdown menus --- */
-header .group{display:inline-flex;gap:.5rem;align-items:center}
 .toolbar{display:flex;flex-wrap:wrap;gap:.5rem;margin-left:auto;align-items:center}
 .menu{position:relative;display:inline-block}
 .menu .menu-trigger{position:relative;padding-right:1.6rem}
 .menu .menu-items{
   position:absolute;top:calc(100% + 6px);left:0;
-  background:#0f1734;border:1px solid #1b254b;border-radius:12px;
+  background:#fff;border:1px solid #dadce0;border-radius:8px;
   min-width:180px;padding:.35rem;display:none;z-index:50;
-  box-shadow:0 8px 24px rgba(0,0,0,.35)
+  box-shadow:0 8px 24px rgba(60,64,67,.15)
 }
 .menu .menu-items.right{right:0;left:auto}
 .menu.open .menu-items{display:block}
@@ -139,10 +142,10 @@ header .group{display:inline-flex;gap:.5rem;align-items:center}
 @media(hover:hover){.menu:hover .menu-items{display:block}}
 .menu .menu-items button{
   display:block;width:100%;text-align:left;
-  background:transparent;border:0;border-radius:8px;
+  background:transparent;border:0;border-radius:4px;
   padding:.5rem .6rem;color:var(--text)
 }
-.menu .menu-items button:hover{background:#21306b}
+.menu .menu-items button:hover{background:var(--sel)}
 
 /* --- Active header highlighting and hover feedback --- */
 thead th.active, tbody th.active{


### PR DESCRIPTION
## Summary
- Move sheet tabs below the grid and add Google-style tab bar
- Insert add-sheet button before sheet tabs
- Convert dark theme to light Google Sheets-inspired styling
- Refine sheet tabs for closer Google Sheets look (compact layout, accent underline, circular add button)
- Rebuild header into a single toolbar with grouped controls and responsive hamburger

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1301768588331a1a56ef69483c4a2