### PR TITLE
feat: add multi-cell selection

### DIFF
--- a/style.css
+++ b/style.css
@@ -26,7 +26,9 @@
   th{padding:.4rem .5rem;text-align:center}
   td{padding:0}
   td .cell{padding:.45rem .5rem;outline:none;min-height:32px}
-  td .cell:focus, td .cell.active{background:var(--sel);box-shadow:inset 0 0 0 2px var(--accent);outline:none}
+  td .cell:focus{outline:none}
+  td .cell.selected{background:var(--sel)}
+  td .cell.active{box-shadow:inset 0 0 0 2px var(--accent);outline:none}
   td .cell.formula-cursor{outline:2px dotted var(--accent);outline-offset:-2px}
   tr:nth-child(even) td{background:var(--grid)}
   tr:nth-child(odd) td{background:var(--grid)}


### PR DESCRIPTION
## Summary
- enable selecting multiple cells via shift-click, dragging, and shift+arrow keys
- apply bold/italic/fill formatting across selected ranges
- style and navigation updates for multi-cell selection

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a1e9adf483319d2d864efc07cad8